### PR TITLE
fix(beam): On direct join, don't render conference until connected

### DIFF
--- a/src/pages/PreviewScreen.jsx
+++ b/src/pages/PreviewScreen.jsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState, useEffect } from "react";
-import { useHistory, useParams, useLocation, Redirect } from "react-router-dom";
+import { useHistory, useParams, useLocation } from "react-router-dom";
 import {
   Button,
   MessageModal,
@@ -154,18 +154,6 @@ const PreviewScreen = ({ getUserToken }) => {
     );
   }
 
-  // This for handling beam recording
-  if (skipPreview) {
-    return loginInfo.token ? (
-      <Redirect to={`/meeting/${urlRoomId}/${userRole}`} />
-    ) : (
-      <div className="h-full">
-        <div className="flex justify-center h-full items-center">
-          <ProgressIcon width="100" height="100" />
-        </div>
-      </div>
-    );
-  }
   return (
     <div className="h-full">
       <div className="flex justify-center h-full items-center">

--- a/src/pages/conference.jsx
+++ b/src/pages/conference.jsx
@@ -7,11 +7,13 @@ import { ConferenceMainView } from "../views/mainView";
 import {
   Button,
   MessageModal,
+  selectIsConnectedToRoom,
   selectRoleChangeRequest,
   useHMSActions,
   useHMSStore,
 } from "@100mslive/hms-video-react";
 import { Notifications } from "../views/components/notifications/Notifications";
+import FullPageProgress from "../views/components/FullPageSpinner";
 
 export const Conference = () => {
   const history = useHistory();
@@ -22,6 +24,7 @@ export const Conference = () => {
   const toggleChat = useCallback(() => {
     setIsChatOpen(open => !open);
   }, []);
+  const isConnectedToRoom = useHMSStore(selectIsConnectedToRoom);
   const roleChangeRequest = useHMSStore(selectRoleChangeRequest);
   const hmsActions = useHMSActions();
 
@@ -47,6 +50,10 @@ export const Conference = () => {
     };
     // eslint-disable-next-line
   }, []);
+
+  if (!isConnectedToRoom) {
+    return <FullPageProgress />;
+  }
 
   return (
     <div className="w-full h-full flex flex-col dark:bg-black">

--- a/src/views/components/FullPageSpinner.jsx
+++ b/src/views/components/FullPageSpinner.jsx
@@ -1,0 +1,11 @@
+import { ProgressIcon } from "@100mslive/hms-video-react";
+
+const FullPageProgress = () => (
+  <div className="h-full">
+    <div className="flex justify-center h-full items-center">
+      <ProgressIcon width="100" height="100" />
+    </div>
+  </div>
+);
+
+export default FullPageProgress;


### PR DESCRIPTION
Problem: Trying to access roles before/during websocket connection - on direct join for beam.
Fix: Don't render conference(which tries to access roles for layout) when not connected to room.