### PR TITLE
Remember user's name for next join

### DIFF
--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -85,4 +85,5 @@ export const defaultVideoList = [
   },
 ];
 
-export const UI_SETTINGS_KEY = 'uiSettings';
+export const UI_SETTINGS_KEY = "uiSettings";
+export const USERNAME_KEY = "loginUsername";

--- a/src/pages/PreviewScreen.jsx
+++ b/src/pages/PreviewScreen.jsx
@@ -11,6 +11,7 @@ import { AppContext } from "../store/AppContext";
 import getToken from "../services/tokenService";
 import { convertLoginInfoToJoinConfig } from "../store/appContextUtils";
 import { Notifications } from "../views/components/notifications/Notifications";
+import { USERNAME_KEY } from "../common/constants";
 
 const PreviewScreen = ({ getUserToken }) => {
   const history = useHistory();
@@ -26,6 +27,8 @@ const PreviewScreen = ({ getUserToken }) => {
   });
   const urlSearchParams = new URLSearchParams(location.search);
   const skipPreview = urlSearchParams.get("token") === "beam_recording";
+
+  const usernameFromStorage = localStorage.getItem(USERNAME_KEY);
 
   useEffect(() => {
     if (skipPreview) {
@@ -168,6 +171,7 @@ const PreviewScreen = ({ getUserToken }) => {
               roomId: urlRoomId,
               token,
               env: loginInfo.env,
+              username: usernameFromStorage,
             })}
           />
         ) : (

--- a/src/store/AppContext.js
+++ b/src/store/AppContext.js
@@ -14,7 +14,7 @@ import {
   setUpLogRocket,
 } from "./appContextUtils";
 import { getBackendEndpoint } from "../services/tokenService";
-import { UI_SETTINGS_KEY } from "../common/constants";
+import { UI_SETTINGS_KEY, USERNAME_KEY } from "../common/constants";
 
 const AppContext = React.createContext(null);
 
@@ -35,8 +35,9 @@ const initialLoginInfo = {
 
 const defaultTokenEndpoint = process.env
   .REACT_APP_TOKEN_GENERATION_ENDPOINT_DOMAIN
-  ? `${getBackendEndpoint()}${process.env.REACT_APP_TOKEN_GENERATION_ENDPOINT_DOMAIN
-  }/`
+  ? `${getBackendEndpoint()}${
+      process.env.REACT_APP_TOKEN_GENERATION_ENDPOINT_DOMAIN
+    }/`
   : process.env.REACT_APP_TOKEN_GENERATION_ENDPOINT;
 
 const envPolicyConfig = JSON.parse(process.env.REACT_APP_POLICY_CONFIG || "{}");
@@ -50,12 +51,12 @@ const envVideoPlaylist = JSON.parse(
 const defaultUiSettings = {
   maxTileCount: 9,
   subscribedNotifications: {
-    "PEER_JOINED": false,
-    "PEER_LEFT": false,
-    "NEW_MESSAGE": false,
-    "ERROR": true
-  }
-}
+    PEER_JOINED: false,
+    PEER_LEFT: false,
+    NEW_MESSAGE: false,
+    ERROR: true,
+  },
+};
 
 const uiSettingsFromStorage = localStorage.getItem(UI_SETTINGS_KEY)
   ? JSON.parse(localStorage.getItem(UI_SETTINGS_KEY))
@@ -84,15 +85,24 @@ const AppContextProvider = ({
     loginInfo: initialLoginInfo,
     maxTileCount: uiSettingsFromStorage.maxTileCount,
     localAppPolicyConfig: {},
-    subscribedNotifications: uiSettingsFromStorage.subscribedNotifications
+    subscribedNotifications: uiSettingsFromStorage.subscribedNotifications,
   });
 
   useEffect(() => {
-    localStorage.setItem(UI_SETTINGS_KEY, JSON.stringify({
-      maxTileCount: state.maxTileCount,
-      subscribedNotifications: state.subscribedNotifications
-    }));
-  }, [state.maxTileCount, state.subscribedNotifications])
+    localStorage.setItem(
+      UI_SETTINGS_KEY,
+      JSON.stringify({
+        maxTileCount: state.maxTileCount,
+        subscribedNotifications: state.subscribedNotifications,
+      })
+    );
+  }, [state.maxTileCount, state.subscribedNotifications]);
+
+  useEffect(() => {
+    if (state.loginInfo.username) {
+      localStorage.setItem(USERNAME_KEY, state.loginInfo.username);
+    }
+  }, [state.loginInfo.username]);
 
   const customLeave = useCallback(() => {
     console.log("User is leaving the room");
@@ -141,7 +151,6 @@ const AppContextProvider = ({
   const deepSetMaxTiles = maxTiles =>
     setState(prevState => ({ ...prevState, maxTileCount: maxTiles }));
 
-
   const deepSetAppPolicyConfig = config =>
     setState(prevState => ({ ...prevState, localAppPolicyConfig: config }));
 
@@ -149,8 +158,9 @@ const AppContextProvider = ({
     setState(prevState => ({
       ...prevState,
       subscribedNotifications: {
-        ...prevState.subscribedNotifications, [notification.type]: notification.isSubscribed
-      }
+        ...prevState.subscribedNotifications,
+        [notification.type]: notification.isSubscribed,
+      },
     }));
 
   return (


### PR DESCRIPTION
The app should now remember the user's name and autofills the name input
on the join screen. This is for issue #453 

I've added another `useEffect` instance to `AppContext.js` that sets the
username stored in `state.loginInfo.username` to `localStorage`. But it
will only do this if the value is truthy, i.e. not `""`.

The username is retrieved from `localStorage` in `PreviewScreen.jsx` and
stored in the variable `usernameFromStorage`. I then pass this value
into the `config` prop (via `convertLoginInfoToJoinConfig()`) of the
`Preview` component.

I've also added `USERNAME_KEY` to constants.js for setting/retrieving
the username from `localStorage`.