### PR TITLE
fix: handle null check for local peer on playlist

### DIFF
--- a/src/views/headerView.jsx
+++ b/src/views/headerView.jsx
@@ -91,6 +91,10 @@ const PlaylistMusic = () => {
     return null;
   }
 
+  if (peer.isLocal && !selection) {
+    return null;
+  }
+
   return (
     <div className="flex items-center">
       <VolumeIcon />


### PR DESCRIPTION
- App is crashing when audio playlist is started because selection is updated after a while. Added null check for selector for the peer who is playing