### PR TITLE
feat: show only one video tile in pip even when 2 video tiles are present

### DIFF
--- a/src/views/PIP/pipUtils.js
+++ b/src/views/PIP/pipUtils.js
@@ -19,7 +19,9 @@ export function drawVideoElementsOnCanvas(videoElements, canvas) {
     // no tile to render, render black image
     ctx.fillRect(0, 0, canvasWidth, canvasHeight);
     return;
-  } else if (numberOfTiles === 1) {
+  }
+  // TODO: Remove case of 2 tiles after aspect-ratio issue is resolved.
+  else if (numberOfTiles === 1 || numberOfTiles === 2) {
     // draw the video element on full canvas
     ctx.drawImage(videoElements[0], 0, 0, canvasWidth, canvasHeight);
     return;


### PR DESCRIPTION
Display only one video in pip element in the case when either 1 or 2 video tiles are present, till the aspect-ratio issue is resolved. 
Reason: The pipVideo element looks worst in the case of 2 video tiles w.r.t aspect-ratio.  