### PR TITLE
feat: add  no-nested-ternary to eslint rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -35,6 +35,7 @@
       }
     ],
     "import/first": "error",
+    "no-nested-ternary": "warning",
     "import/no-duplicates": "error",
     "simple-import-sort/imports": [
       "error",


### PR DESCRIPTION
## Scope
A developer girl shouldn't have to hurt her brain to understand the logic flow in the application. Adding in warnings that nested-ternaries are not acceptable is a step in that direction.

### More context
The app is littered in deeply nested ternaries, which by their nature is super hard to reason about and read. Considering this is a sample app, a lot of people are going to be reading the code. 

## Work Done
Added  'no-nested-ternary': 'error' to the eslint rules. Ideally this would be an error, but would create a lot of code needing to be updated before this could go in. 

## Steps to test
Add a nested ternary. Eslint should give you a warning. 

## GIF tax
![](https://media.giphy.com/media/RNDdIRbOM7hKH9ezKz/giphy.gif)