### PR TITLE
Fixes eslintrc warning for no-nested-ternary

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -35,7 +35,7 @@
       }
     ],
     "import/first": "error",
-    "no-nested-ternary": "warning",
+    "no-nested-ternary": 1,
     "import/no-duplicates": "error",
     "simple-import-sort/imports": [
       "error",


### PR DESCRIPTION
Noticed, if you create a new repository using the template, it throws an error when trying to deploy to Vercel.

<img width="859" alt="Screenshot 2023-10-24 at 11 17 08 AM" src="https://github.com/100mslive/100ms-web/assets/53579386/e49be947-b276-4faf-8e8a-e9b9d83eb846">

It can be locally reproduced by running the command - `yarn run build` 

<img width="949" alt="Screenshot 2023-10-24 at 11 19 54 AM" src="https://github.com/100mslive/100ms-web/assets/53579386/b616825a-2abe-4b2e-9926-45b0456af0db">

```
ERROR in [eslint] .eslintrc:
        Configuration for rule "no-nested-ternary" is invalid:
        Severity should be one of the following: 0 = off, 1 = warn, 2 = error (you passed '"warning"').
```

Have created a fix for the same as suggested in the message.