### PR TITLE
Fixes the no-nested-ternary warning

### DIFF
--- a/src/components/AppData/useSidepane.js
+++ b/src/components/AppData/useSidepane.js
@@ -50,13 +50,18 @@ export const useWidgetToggle = () => {
   const toggleWidget = useCallback(
     id => {
       id = typeof id === "string" ? id : undefined;
+      let viewToShow;
+      if (id) {
+        viewToShow = WIDGET_VIEWS.VOTE;
+      } else if (widgetView) {
+        viewToShow = null;
+      } else {
+        viewToShow = WIDGET_VIEWS.LANDING;
+      }
+
       setWidgetState({
         [WIDGET_STATE.pollInView]: id,
-        [WIDGET_STATE.view]: id
-          ? WIDGET_VIEWS.VOTE
-          : widgetView
-          ? null
-          : WIDGET_VIEWS.LANDING,
+        [WIDGET_STATE.view]: viewToShow,
       });
     },
     [widgetView, setWidgetState]

--- a/src/components/Chat/Chat.js
+++ b/src/components/Chat/Chat.js
@@ -70,14 +70,19 @@ export const Chat = () => {
     CHAT_SELECTOR.ROLE
   );
   const peerName = useHMSStore(selectPeerNameByID(peerSelector));
-  const [chatOptions, setChatOptions] = useState({
-    role: roleSelector || "",
-    peerId: peerSelector && peerName ? peerSelector : "",
-    selection: roleSelector
-      ? roleSelector
-      : peerSelector && peerName
-      ? peerName
-      : "Everyone",
+  const [chatOptions, setChatOptions] = useState(() => {
+    const roleValue = roleSelector || "";
+    const peerIdValue = peerSelector && peerName ? peerSelector : "";
+    const selectionValue =
+      roleSelector || (peerSelector && peerName)
+        ? roleSelector || peerName
+        : "Everyone";
+
+    return {
+      role: roleValue,
+      peerId: peerIdValue,
+      selection: selectionValue,
+    };
   });
   const [isSelectorOpen, setSelectorOpen] = useState(false);
   const listRef = useRef(null);

--- a/src/components/Chat/useUnreadCount.js
+++ b/src/components/Chat/useUnreadCount.js
@@ -6,11 +6,15 @@ import {
 } from "@100mslive/react-sdk";
 
 export const useUnreadCount = ({ role, peerId }) => {
-  const unreadCountSelector = role
-    ? selectMessagesUnreadCountByRole(role)
-    : peerId
-    ? selectMessagesUnreadCountByPeerID(peerId)
-    : selectUnreadHMSMessagesCount;
+  let unreadCountSelector;
+
+  if (role) {
+    unreadCountSelector = selectMessagesUnreadCountByRole(role);
+  } else if (peerId) {
+    unreadCountSelector = selectMessagesUnreadCountByPeerID(peerId);
+  } else {
+    unreadCountSelector = selectUnreadHMSMessagesCount;
+  }
 
   const unreadCount = useHMSStore(unreadCountSelector);
   return unreadCount;

--- a/src/components/hooks/useSetPinnedMessage.js
+++ b/src/components/hooks/useSetPinnedMessage.js
@@ -1,4 +1,3 @@
-// @ts-check
 import { useCallback } from "react";
 import {
   selectPeerNameByID,
@@ -23,14 +22,16 @@ export const useSetPinnedMessage = () => {
      * @param {import("@100mslive/react-sdk").HMSMessage | undefined} message
      */
     async message => {
+      const senderId = message?.sender;
       const peerName =
-        vanillaStore.getState(selectPeerNameByID(message?.sender)) ||
+        vanillaStore.getState(selectPeerNameByID(senderId)) ||
         message?.senderName;
-      const newPinnedMessage = message
-        ? peerName
-          ? `${peerName}: ${message.message}`
-          : message.message
-        : null;
+
+      const messageContent = message ? message.message : null;
+      const newPinnedMessage = peerName
+        ? `${peerName}: ${messageContent}`
+        : messageContent;
+
       if (newPinnedMessage !== pinnedMessage) {
         await hmsActions.sessionStore
           .set(SESSION_STORE_KEY.PINNED_MESSAGE, newPinnedMessage)


### PR DESCRIPTION
If we setup the web sample locally and run the `yarn` command to get dependencies and `yarn start`, it shows the no-nested-ternary warnings. 

<img width="1512" alt="Screenshot 2024-01-23 at 11 35 53 AM" src="https://github.com/100mslive/100ms-web/assets/53579386/bcbbd87e-f84b-4a06-b84f-2636f8823bc4">

This PR fixes these warning by changing the expressions causing it.

